### PR TITLE
make \insert cmd to generic in common.tex

### DIFF
--- a/common.tex
+++ b/common.tex
@@ -39,6 +39,13 @@
 \setlength\parindent{0pt}
 \def\arraystretch{1.5}
 
+% LECTURE
+\def\padzeros#1{\ifnum#1<10 0\fi\number#1}
+\newcommand{\lecture}[1]{
+	\def\lecnum{#1}
+	\def\paddedlecnum{\padzeros{#1}}
+}
+\def\insert#1{\input{lec\paddedlecnum/#1}}
 
 % FRONT
 \newcommand{\front}[2]{

--- a/lec01.tex
+++ b/lec01.tex
@@ -4,8 +4,8 @@
 %}
 
 \begin{document}
-	\def\lecnum{1}
-	\def\insert#1{\input{lec01/#1}} % TODO common 
+
+\lecture{1}
 	
 \front{הקדמה}{%
 חיפוש בגרפים,

--- a/lec02.tex
+++ b/lec02.tex
@@ -5,8 +5,7 @@
 
 \begin{document}
 
-\def\lecnum{2}
-\def\insert#1{\input{./lec02/#1}}
+\lecture{2}
 
 \front{חיפוש לעומק -
 \textenglish{Depth First Search (DFS)}}{}

--- a/lec03.tex
+++ b/lec03.tex
@@ -6,8 +6,7 @@
 
 \begin{document}
 	
-\def\lecnum{3}
-\def\insert#1{\input{lec03/#1}}
+\lecture{3}
 
 \front{DFS}{%
 רכיבים קשירים היטב, צמתי הפרדה, רכיבים אי פריקים%

--- a/lec04.tex
+++ b/lec04.tex
@@ -5,8 +5,8 @@
 
 
 \begin{document}
-	\def\lecnum{4}
-	\def\insert#1{\input{lec04/#1}}
+
+\lecture{4}
 	
 \front{%
 עץ פורש מינימלי%

--- a/lec05.tex
+++ b/lec05.tex
@@ -6,8 +6,7 @@
 
 \begin{document}
 	
-	\def\lecnum{5}
-	\def\insert#1{\input{lec05/#1}}
+\lecture{5}
 	
 	
 \front{אלגוריתמים חמדניים}{%

--- a/lec06.tex
+++ b/lec06.tex
@@ -6,8 +6,7 @@
 
 \begin{document}
 	
-	\def\lecnum{6}
-	\def\insert#1{\input{lec06/#1}}
+\lecture{6}
 	
 \front{%
 קוד האפמן%

--- a/lec07.tex
+++ b/lec07.tex
@@ -5,9 +5,9 @@
 
 
 \begin{document}
-	\def\lecnum{7}
-	\def\insert#1{\input{lec07/#1}}
-	
+
+\lecture{7}
+
 \front{%
 מסלולים קלים ביותר%
 }{%

--- a/lec08.tex
+++ b/lec08.tex
@@ -2,8 +2,8 @@
 \documentclass[]{article}
 \input{common}
 \begin{document}
-	\def\lecnum{8}
-	\def\insert#1{\input{lec08/#1}}
+
+\lecture{8}
 	
 \front{%
 מסלולים קלים ביותר%

--- a/lec09.tex
+++ b/lec09.tex
@@ -5,8 +5,8 @@
 
 
 \begin{document}
-	\def\lecnum{9}
-	\def\insert#1{\input{lec09/#1}}
+
+\lecture{9}
 	
 \front{%
 תכנון דינאמי%

--- a/lec10.tex
+++ b/lec10.tex
@@ -6,8 +6,7 @@
 
 \begin{document}
 	
-	\def\lecnum{10}
-	\def\insert#1{\input{lec\lecnum/#1}}
+\lecture{10}
 	
 \front{%
 תכנון דינאמי%

--- a/lec11.tex
+++ b/lec11.tex
@@ -3,8 +3,9 @@
 \input{common}
 
 \begin{document}
-	\def\lecnum{11}
-	\def\insert#1{\input{lec\lecnum/#1}}
+
+\lecture{11}
+
 \front{%
 רשתות זרימה%
 }{%

--- a/lec12.tex
+++ b/lec12.tex
@@ -4,8 +4,9 @@
 
 
 \begin{document}
-	\def\lecnum{12}
-	\def\insert#1{\input{lec\lecnum/#1}}
+
+\lecture{12}
+
 \front{%
 רשתות זרימה%
 }{


### PR DESCRIPTION
i've made a new \lecture command that is used inside of each lecture to define \lecnum and \padlecnum. The \insert command (now defined only in common.tex) uses the \padlecnum to know what dir to insert from.